### PR TITLE
fix: restrict Letta Code triggers to owner-only access

### DIFF
--- a/.github/workflows/letta.yml
+++ b/.github/workflows/letta.yml
@@ -1,16 +1,19 @@
 name: Letta Code
 
 on:
+  issues:
+    types: [opened, labeled, assigned]
   issue_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
+  pull_request:
+    types: [opened, labeled]
   pull_request_review_comment:
     types: [created]
 
 jobs:
   letta:
     runs-on: ubuntu-latest
+    if: github.actor == 'greedychipmunk'
     permissions:
       contents: write
       issues: write
@@ -23,3 +26,4 @@ jobs:
         with:
           letta_api_key: ${{ secrets.LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          assignee_trigger: letta-code


### PR DESCRIPTION
## Summary
- Gate the entire job with `if: github.actor == greedychipmunk` so only the repo owner can trigger the agent
- Set `assignee_trigger: letta-code` — assigning an issue to the agent activates it (not assigning to the owner)
- Add `labeled` and `assigned` event types for issues, `labeled` for PRs

## Triggers (all gated to owner only)
| Trigger | How |
|---------|-----|
| Mention | `@letta-code` in comment/issue/PR body |
| Label | Add `letta-code` label to issue or PR |
| Assignee | Assign issue to `letta-code` user |

## Test plan
- [ ] Create a test issue and comment `@letta-code` — agent should respond
- [ ] Add `letta-code` label to an issue — agent should respond
- [ ] Assign an issue to `letta-code` — agent should respond
- [ ] Have another user comment `@letta-code` — agent should NOT respond (job skipped by `if` guard)
- [ ] Assign an issue to `greedychipmunk` — agent should NOT respond

👾 Generated with [Letta Code](https://letta.com)